### PR TITLE
Added xml encoding to htmlentities

### DIFF
--- a/src/Label305/DocxExtractor/Decorated/Sentence.php
+++ b/src/Label305/DocxExtractor/Decorated/Sentence.php
@@ -66,7 +66,7 @@ class Sentence {
             $value .= "<w:br/>";
         }
 
-        $value .= '<w:t xml:space="preserve">' . htmlentities($this->text) . "</w:t></w:r>";
+        $value .= '<w:t xml:space="preserve">' . htmlentities($this->text, ENT_XML1) . "</w:t></w:r>";
 
         return $value;
     }


### PR DESCRIPTION
@JBlaak 

Tekens als `ü` die veel worden gebruikt in het Duits, gaan nu goed.