### PR TITLE
Accept incomplete html

### DIFF
--- a/src/Label305/DocxExtractor/Decorated/Paragraph.php
+++ b/src/Label305/DocxExtractor/Decorated/Paragraph.php
@@ -26,10 +26,13 @@ class Paragraph extends ArrayObject {
         $html = str_replace("<br>", "<br />", $html);
         $html = str_replace("&nbsp;", " ", $html);
         $htmlDom = new DOMDocument;
-        $htmlDom->loadXml(preg_replace('/&(?!#?[a-z0-9]+;)/', '&amp;', html_entity_decode($html)));
+        @$htmlDom->loadXml(preg_replace('/&(?!#?[a-z0-9]+;)/', '&amp;', html_entity_decode($html)));
 
         $paragraph = new Paragraph();
-        $paragraph->fillWithHTMLDom($htmlDom->documentElement);
+        if ($htmlDom->documentElement !== null) {
+            $paragraph->fillWithHTMLDom($htmlDom->documentElement);
+        }
+
         return $paragraph;
     }
 


### PR DESCRIPTION
@remystr Wanneer in een document bijvoorbeeld `<VARIABLE>` aangegeven wordt om aam te geven dart daar bv een naam komt, dan denkt de extractor dat dit een HTML tag is die afgesloten moet worden met `</VARIABLE>`.

Met deze aanpassing kan hij ook omgaan met incorrect geformatte HTML.